### PR TITLE
Feat/enable neopixel

### DIFF
--- a/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/Marlin/Configuration.h
+++ b/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/Marlin/Configuration.h
@@ -802,7 +802,7 @@
  *
  * Enable this option for a probe connected to the Z Min endstop pin.
  */
-#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
+//#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_PIN
@@ -909,7 +909,7 @@
  *
  * Specify a Probe position as { X, Y, Z }
  */
-#define NOZZLE_TO_PROBE_OFFSET { 10, 10, 0 }
+#define NOZZLE_TO_PROBE_OFFSET { -40, -10, -1.85 }
 
 // Certain types of probes need to stay away from edges
 #define MIN_PROBE_EDGE 10
@@ -1160,7 +1160,7 @@
  * Normally G28 leaves leveling disabled on completion. Enable
  * this option to have G28 restore the prior leveling state.
  */
-//#define RESTORE_LEVELING_AFTER_G28
+#define RESTORE_LEVELING_AFTER_G28
 
 /**
  * Enable detailed logging of G28, G29, M48, etc.
@@ -1198,7 +1198,7 @@
 #if EITHER(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)
 
   // Set the number of grid points per dimension.
-  #define GRID_MAX_POINTS_X 3
+  #define GRID_MAX_POINTS_X 5
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 
   // Probe along the Y axis, advancing X after each column
@@ -2145,11 +2145,11 @@
 #define NEOPIXEL_LED
 #if ENABLED(NEOPIXEL_LED)
   #define NEOPIXEL_TYPE   NEO_GRB // NEO_GRBW / NEO_GRB - four/three channel driver type (defined in Adafruit_NeoPixel.h)
-  #define NEOPIXEL_PIN     PC7       // LED driving pin
+  #define NEOPIXEL_PIN    PC7     // LED driving pin
   //#define NEOPIXEL2_TYPE NEOPIXEL_TYPE
   //#define NEOPIXEL2_PIN    5
   #define NEOPIXEL_PIXELS 8       // Number of LEDs in the strip, larger of 2 strips if 2 neopixel strips are used
-  //#define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
+  #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   #define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 

--- a/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/Marlin/Configuration.h
+++ b/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/Marlin/Configuration.h
@@ -71,7 +71,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(BIGTREETECH, SKR-mini-E3-V1.2)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(johnmcclumpha, SKR-mini-E3-V1.2 w NeoPixel)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 /**
@@ -802,7 +802,7 @@
  *
  * Enable this option for a probe connected to the Z Min endstop pin.
  */
-//#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
+#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_PIN
@@ -909,7 +909,7 @@
  *
  * Specify a Probe position as { X, Y, Z }
  */
-#define NOZZLE_TO_PROBE_OFFSET { -40, -10, -1.85 }
+#define NOZZLE_TO_PROBE_OFFSET { 10, 10, 0 }
 
 // Certain types of probes need to stay away from edges
 #define MIN_PROBE_EDGE 10
@@ -1160,7 +1160,7 @@
  * Normally G28 leaves leveling disabled on completion. Enable
  * this option to have G28 restore the prior leveling state.
  */
-#define RESTORE_LEVELING_AFTER_G28
+//#define RESTORE_LEVELING_AFTER_G28
 
 /**
  * Enable detailed logging of G28, G29, M48, etc.
@@ -1198,7 +1198,7 @@
 #if EITHER(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)
 
   // Set the number of grid points per dimension.
-  #define GRID_MAX_POINTS_X 5
+  #define GRID_MAX_POINTS_X 3
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 
   // Probe along the Y axis, advancing X after each column
@@ -2142,13 +2142,13 @@
 #endif
 
 // Support for Adafruit Neopixel LED driver
-// #define NEOPIXEL_LED
+//#define NEOPIXEL_LED
 #if ENABLED(NEOPIXEL_LED)
   #define NEOPIXEL_TYPE   NEO_GRB // NEO_GRBW / NEO_GRB - four/three channel driver type (defined in Adafruit_NeoPixel.h)
-  //#define NEOPIXEL_PIN     4       // LED driving pin
+  // #define NEOPIXEL_PIN     4       // LED driving pin
   //#define NEOPIXEL2_TYPE NEOPIXEL_TYPE
   //#define NEOPIXEL2_PIN    5
-  #define NEOPIXEL_PIXELS 4       // Number of LEDs in the strip, larger of 2 strips if 2 neopixel strips are used
+  #define NEOPIXEL_PIXELS 8       // Number of LEDs in the strip, larger of 2 strips if 2 neopixel strips are used
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   #define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/Marlin/Configuration.h
+++ b/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/Marlin/Configuration.h
@@ -2142,14 +2142,14 @@
 #endif
 
 // Support for Adafruit Neopixel LED driver
-//#define NEOPIXEL_LED
+#define NEOPIXEL_LED
 #if ENABLED(NEOPIXEL_LED)
   #define NEOPIXEL_TYPE   NEO_GRB // NEO_GRBW / NEO_GRB - four/three channel driver type (defined in Adafruit_NeoPixel.h)
-  // #define NEOPIXEL_PIN     4       // LED driving pin
+  #define NEOPIXEL_PIN     PC7       // LED driving pin
   //#define NEOPIXEL2_TYPE NEOPIXEL_TYPE
   //#define NEOPIXEL2_PIN    5
   #define NEOPIXEL_PIXELS 8       // Number of LEDs in the strip, larger of 2 strips if 2 neopixel strips are used
-  #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
+  //#define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   #define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 

--- a/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/platformio.ini
+++ b/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/platformio.ini
@@ -330,7 +330,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore        = SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -346,7 +346,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore        = SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -362,7 +362,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore        = SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -378,7 +378,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore        = SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 

--- a/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/platformio.ini
+++ b/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/platformio.ini
@@ -248,7 +248,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   -DDEBUG_LEVEL=0
 build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
-lib_ignore    = SPI
+lib_ignore    = Adafruit NeoPixel, SPI
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed = 250000
 debug_tool    = stlink
@@ -270,7 +270,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = SPI
+lib_ignore        = Adafruit NeoPixel, SPI
 lib_ldf_mode      = chain
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 250000
@@ -330,7 +330,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = SPI
+lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -346,7 +346,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = SPI
+lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -362,7 +362,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = SPI
+lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -378,7 +378,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = SPI
+lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -391,7 +391,7 @@ framework     = arduino
 board         = disco_f407vg
 build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F4 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB -DHAL_IWDG_MODULE_ENABLED
 lib_deps      = ${common.lib_deps}
-lib_ignore    = TMCStepper
+lib_ignore    = Adafruit NeoPixel, TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F7>
 monitor_speed = 250000
 
@@ -404,7 +404,7 @@ framework     = arduino
 board         = remram_v1
 build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F7 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB -DHAL_IWDG_MODULE_ENABLED
 lib_deps      = ${common.lib_deps}
-lib_ignore    = TMCStepper
+lib_ignore    = Adafruit NeoPixel, TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F4>
 monitor_speed = 250000
 
@@ -420,7 +420,7 @@ build_flags   = ${common.build_flags}
   -O2 -ffreestanding -fsigned-char -fno-move-loop-invariants -fno-strict-aliasing -std=gnu11 -std=gnu++11
   -IMarlin/src/HAL/HAL_STM32
 lib_deps      = ${common.lib_deps}
-lib_ignore    = SoftwareSerial
+lib_ignore    = Adafruit NeoPixel, SoftwareSerial
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 250000
 
@@ -439,7 +439,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = LiquidTWI2, SPI
+lib_ignore    = Adafruit NeoPixel, LiquidTWI2, SPI
 
 #
 # MKS Robin (STM32F103ZET6)
@@ -454,7 +454,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = SPI
+lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # MKS ROBIN LITE/LITE2 (STM32F103RCT6)
@@ -469,7 +469,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = SPI
+lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # MKS Robin Mini (STM32F103VET6)
@@ -484,7 +484,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = SPI
+lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # MKS Robin Nano (STM32F103VET6)
@@ -499,7 +499,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = SPI
+lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # JGAurora A5S A1 (STM32F103ZET6)
@@ -514,7 +514,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = SPI
+lib_ignore    = Adafruit NeoPixel, SPI
 monitor_speed = 250000
 
 #
@@ -533,7 +533,7 @@ build_flags       = ${common.build_flags}
  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"BLACK_F407VE\"
   -IMarlin/src/HAL/HAL_STM32
 lib_deps          = ${common.lib_deps}
-lib_ignore        = TMCStepper, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster, SoftwareSerial
+lib_ignore        = Adafruit NeoPixel, TMCStepper, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster, SoftwareSerial
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed     = 250000
 
@@ -578,7 +578,7 @@ build_flags   = ${common.build_flags}
   -DPIN_SERIAL2_RX=PD_6
   -DPIN_SERIAL2_TX=PD_5
 lib_deps      = ${common.lib_deps}
-lib_ignore    = SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster
+lib_ignore    = Adafruit NeoPixel, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 250000
 
@@ -592,6 +592,7 @@ board         = teensy31
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
+lib_ignore    = Adafruit NeoPixel
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_TEENSY31_32>
 monitor_speed = 250000
 
@@ -605,7 +606,7 @@ board       = malyanM200
 build_flags = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py -DMCU_STM32F103CB -D __STM32F1__=1 -std=c++1y -D MOTHERBOARD="BOARD_MALYAN_M200" -DSERIAL_USB -ffunction-sections -fdata-sections -Wl,--gc-sections
   -DDEBUG_LEVEL=0 -D__MARLIN_FIRMWARE__
 src_filter  = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_ignore  = LiquidCrystal, LiquidTWI2, TMCStepper, U8glib-HAL, SPI
+lib_ignore  = Adafruit NeoPixel, LiquidCrystal, LiquidTWI2, TMCStepper, U8glib-HAL, SPI
 
 #
 # Chitu boards like Tronxy X5s (STM32F103ZET6)
@@ -620,6 +621,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG= -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
+lib_ignore    = Adafruit NeoPixel
 
 #
 # Teensy 3.5 / 3.6 (ARM Cortex-M4)
@@ -631,6 +633,7 @@ board         = teensy35
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
+lib_ignore    = Adafruit NeoPixel
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_TEENSY35_36>
 monitor_speed = 250000
 

--- a/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/platformio.ini
+++ b/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/platformio.ini
@@ -248,7 +248,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   -DDEBUG_LEVEL=0
 build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
+lib_ignore    = SPI
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed = 250000
 debug_tool    = stlink
@@ -270,7 +270,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore        = SPI
 lib_ldf_mode      = chain
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 250000
@@ -330,7 +330,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore        = SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -346,7 +346,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore        = SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -362,7 +362,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore        = SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -378,7 +378,7 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore        = SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
@@ -391,7 +391,7 @@ framework     = arduino
 board         = disco_f407vg
 build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F4 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB -DHAL_IWDG_MODULE_ENABLED
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, TMCStepper
+lib_ignore    = TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F7>
 monitor_speed = 250000
 
@@ -404,7 +404,7 @@ framework     = arduino
 board         = remram_v1
 build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F7 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB -DHAL_IWDG_MODULE_ENABLED
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, TMCStepper
+lib_ignore    = TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F4>
 monitor_speed = 250000
 
@@ -420,7 +420,7 @@ build_flags   = ${common.build_flags}
   -O2 -ffreestanding -fsigned-char -fno-move-loop-invariants -fno-strict-aliasing -std=gnu11 -std=gnu++11
   -IMarlin/src/HAL/HAL_STM32
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SoftwareSerial
+lib_ignore    = SoftwareSerial
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 250000
 
@@ -439,7 +439,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, LiquidTWI2, SPI
+lib_ignore    = LiquidTWI2, SPI
 
 #
 # MKS Robin (STM32F103ZET6)
@@ -454,7 +454,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
+lib_ignore    = SPI
 
 #
 # MKS ROBIN LITE/LITE2 (STM32F103RCT6)
@@ -469,7 +469,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
+lib_ignore    = SPI
 
 #
 # MKS Robin Mini (STM32F103VET6)
@@ -484,7 +484,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
+lib_ignore    = SPI
 
 #
 # MKS Robin Nano (STM32F103VET6)
@@ -499,7 +499,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
+lib_ignore    = SPI
 
 #
 # JGAurora A5S A1 (STM32F103ZET6)
@@ -514,7 +514,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
+lib_ignore    = SPI
 monitor_speed = 250000
 
 #
@@ -533,7 +533,7 @@ build_flags       = ${common.build_flags}
  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"BLACK_F407VE\"
   -IMarlin/src/HAL/HAL_STM32
 lib_deps          = ${common.lib_deps}
-lib_ignore        = Adafruit NeoPixel, TMCStepper, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster, SoftwareSerial
+lib_ignore        = TMCStepper, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster, SoftwareSerial
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed     = 250000
 
@@ -578,7 +578,7 @@ build_flags   = ${common.build_flags}
   -DPIN_SERIAL2_RX=PD_6
   -DPIN_SERIAL2_TX=PD_5
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster
+lib_ignore    = SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 250000
 
@@ -592,7 +592,6 @@ board         = teensy31
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-lib_ignore    = Adafruit NeoPixel
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_TEENSY31_32>
 monitor_speed = 250000
 
@@ -606,7 +605,7 @@ board       = malyanM200
 build_flags = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py -DMCU_STM32F103CB -D __STM32F1__=1 -std=c++1y -D MOTHERBOARD="BOARD_MALYAN_M200" -DSERIAL_USB -ffunction-sections -fdata-sections -Wl,--gc-sections
   -DDEBUG_LEVEL=0 -D__MARLIN_FIRMWARE__
 src_filter  = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_ignore  = Adafruit NeoPixel, LiquidCrystal, LiquidTWI2, TMCStepper, U8glib-HAL, SPI
+lib_ignore  = LiquidCrystal, LiquidTWI2, TMCStepper, U8glib-HAL, SPI
 
 #
 # Chitu boards like Tronxy X5s (STM32F103ZET6)
@@ -621,7 +620,6 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG= -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel
 
 #
 # Teensy 3.5 / 3.6 (ARM Cortex-M4)
@@ -633,7 +631,6 @@ board         = teensy35
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-lib_ignore    = Adafruit NeoPixel
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_TEENSY35_36>
 monitor_speed = 250000
 


### PR DESCRIPTION
- Enables the AdaFruit library by removing from various lib_ignores
- Defines NEOPIXEL_LED to enable NeoPixel
- Sets NEOPIXEL_PIN to PC7 as per https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/blob/master/hardware/BTT%20SKR%20MINI%20E3%20V1.2/BTT%20SKR%20MINI%20E3%20V1.2PIN.pdf
- set NEOPIXEL_PIXELS to 8 for use with NeoPixel Stick 8: https://www.adafruit.com/product/1426